### PR TITLE
Load JSON from Shadertoy API

### DIFF
--- a/Shadertoy-Screensaver/Shadertoy_ScreensaverView.m
+++ b/Shadertoy-Screensaver/Shadertoy_ScreensaverView.m
@@ -29,13 +29,6 @@ static NSString * const MyModuleName = @"diracdrifter.Shadertoy-Screensaver";
 
         defaults = [ScreenSaverDefaults defaultsForModuleWithName:MyModuleName];
 
-        // Register our default values
-        [defaults registerDefaults:[NSDictionary dictionaryWithObjectsAndKeys:
-                   @"NO", @"DrawFilledShapes",
-                   @"NO", @"DrawOutlinedShapes",
-                   @"YES", @"DrawBoth",
-                   nil]];
-
         self.time = 0.0;
         self.iFrame = 0;
 
@@ -73,11 +66,23 @@ static NSString * const MyModuleName = @"diracdrifter.Shadertoy-Screensaver";
 
         NSString *header = [self createShadertoyHeader];
 
-        NSDictionary *shaderInfo = [self JSONFromFile:@"shader.json"];
-        NSString *shadertoyCode = [self getShaderStringFromJSON:shaderInfo];
+        // Uncomment to get shader from file
+        //NSDictionary *shaderInfo = [self JSONFromFile:@"shader.json"];
+        //NSString *shadertoyCode = [self getShaderStringFromJSON:shaderInfo];
 
-        // TODO: Add getting shadertoy info here from defaults
-        // TODO: Add getting json dictionary from the shadertoy info
+        // TODO: Add failsafe by loading shader from disk instead
+
+        NSLog(@"before getting default");
+        NSString *shadertoyJson = [defaults stringForKey:@"ShaderJSON"];
+        NSLog(@"shadertoyJson %@", shadertoyJson);
+
+        NSDictionary *shaderInfo = [self JSONFromString:shadertoyJson];
+
+        // TODO Remove this
+        NSDictionary *shaderfrominfo = [shaderInfo objectForKey:@"Shader"];
+        NSLog(@"shader version: %@", [shaderfrominfo objectForKey:@"ver"]);
+
+        NSString *shadertoyCode = [self getShaderStringFromJSON:shaderInfo];
 
         NSLog(@"shadertoyCode: %@", shadertoyCode);
 
@@ -328,6 +333,12 @@ GLuint compileShader(GLenum type, NSString *source)
     //NSString *jsonString = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:&error];
     //NSLog(@"jsonString: %@", jsonString);
     NSData *data = [NSData dataWithContentsOfFile:path];
+    return [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
+}
+
+- (NSDictionary *)JSONFromString:(NSString *)jsonString
+{
+    NSData *data = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
     return [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
 }
 

--- a/Shadertoy-Screensaver/Shadertoy_ScreensaverView.m
+++ b/Shadertoy-Screensaver/Shadertoy_ScreensaverView.m
@@ -76,6 +76,9 @@ static NSString * const MyModuleName = @"diracdrifter.Shadertoy-Screensaver";
         NSDictionary *shaderInfo = [self JSONFromFile:@"shader.json"];
         NSString *shadertoyCode = [self getShaderStringFromJSON:shaderInfo];
 
+        // TODO: Add getting shadertoy info here from defaults
+        // TODO: Add getting json dictionary from the shadertoy info
+
         NSLog(@"shadertoyCode: %@", shadertoyCode);
 
         //NSString *fragmentShaderString = [header stringByAppendingString:[self loadShader:@"fragmentshader.glsl"]];

--- a/Shadertoy_ScreensaverConfigSheet.h
+++ b/Shadertoy_ScreensaverConfigSheet.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface Shadertoy_ScreensaverConfigSheet : NSWindowController
 
+// TODO Remove textField
 @property (nonatomic, weak) IBOutlet NSTextField *textField;
 @property (weak) IBOutlet NSTextField *shadertoyUrlTextField;
 @property (weak) IBOutlet NSTextField *shadertoyAPIKeyTextField;

--- a/Shadertoy_ScreensaverConfigSheet.h
+++ b/Shadertoy_ScreensaverConfigSheet.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // TODO Remove textField
 @property (nonatomic, weak) IBOutlet NSTextField *textField;
-@property (weak) IBOutlet NSTextField *shadertoyUrlTextField;
+@property (weak) IBOutlet NSTextField *shadertoyShaderIDTextField;
 @property (weak) IBOutlet NSTextField *shadertoyAPIKeyTextField;
 
 

--- a/Shadertoy_ScreensaverConfigSheet.m
+++ b/Shadertoy_ScreensaverConfigSheet.m
@@ -23,6 +23,8 @@ static NSString * const MyModuleName = @"diracdrifter.Shadertoy-Screensaver";
     NSUserDefaults *defaults = [ScreenSaverDefaults defaultsForModuleWithName:MyModuleName];
     NSString *shadertoyUrl = [defaults stringForKey:@"ShadertoyUrl"];
     NSString *shadertoyApiKey = [defaults stringForKey:@"ShadertoyApiKey"];
+    NSString *shaderJson = [defaults stringForKey:@"ShaderJSON"];
+    NSLog(@"shaderJson in configsheet %@", shaderJson);
     [self.shadertoyUrlTextField setStringValue:shadertoyUrl];
     [self.shadertoyAPIKeyTextField setStringValue:shadertoyApiKey];
 }
@@ -40,7 +42,7 @@ static NSString * const MyModuleName = @"diracdrifter.Shadertoy-Screensaver";
     NSString *request = [self createRequestString:currentUrl apiKey:currentApiKey];
     NSString *shaderJson = [self getShaderJson:request];
     NSLog(@"shaderJson: %@", shaderJson);
-    //[defaults setObject:shaderJson forKey:@"ShaderJSON"];
+    [defaults setObject:shaderJson forKey:@"ShaderJSON"];
 
     [defaults synchronize];
 

--- a/Shadertoy_ScreensaverConfigSheet.m
+++ b/Shadertoy_ScreensaverConfigSheet.m
@@ -37,9 +37,43 @@ static NSString * const MyModuleName = @"diracdrifter.Shadertoy-Screensaver";
     NSString *currentApiKey = [self.shadertoyAPIKeyTextField stringValue];
     [defaults setObject:currentApiKey forKey:@"ShadertoyApiKey"];
 
+    NSString *request = [self createRequestString:currentUrl apiKey:currentApiKey];
+    NSString *shaderJson = [self getShaderJson:request];
+    NSLog(@"shaderJson: %@", shaderJson);
+    //[defaults setObject:shaderJson forKey:@"ShaderJSON"];
+
     [defaults synchronize];
 
     [[NSApplication sharedApplication] endSheet:self.window];
+}
+
+- (NSString *)createRequestString:(NSString*)url apiKey:(NSString*)apiKey
+{
+    NSString *baseUrl = @"https://www.shadertoy.com/api/v1/shaders/";
+    NSString *urlWithShader = [baseUrl stringByAppendingString:url];
+    NSString *urlWithApiKey = [[urlWithShader stringByAppendingString:@"?key="] stringByAppendingString:apiKey];
+
+    return urlWithApiKey;
+}
+
+- (NSString *)getShaderJson:(NSString*)fullURL
+{
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
+    [request setHTTPMethod:@"GET"];
+    [request setURL:[NSURL URLWithString:fullURL]];
+    NSError *error;
+    NSHTTPURLResponse *responseCode = nil;
+
+    // Deprecated: see xcode warning
+    NSData *oResponseData = [NSURLConnection sendSynchronousRequest:request returningResponse:&responseCode error:&error];
+
+    NSInteger statusCode = [responseCode statusCode];
+
+    if(statusCode != 200) {
+        NSLog(@"status code %i from request to %@", statusCode, fullURL);
+    }
+
+    return [[NSString alloc] initWithData:oResponseData encoding:NSUTF8StringEncoding];
 }
 
 @end

--- a/Shadertoy_ScreensaverConfigSheet.m
+++ b/Shadertoy_ScreensaverConfigSheet.m
@@ -21,11 +21,11 @@ static NSString * const MyModuleName = @"diracdrifter.Shadertoy-Screensaver";
 
     // Implement this method to handle any initialization after your window controller's window has been loaded from its nib file.
     NSUserDefaults *defaults = [ScreenSaverDefaults defaultsForModuleWithName:MyModuleName];
-    NSString *shadertoyUrl = [defaults stringForKey:@"ShadertoyUrl"];
+    NSString *shadertoyShaderID = [defaults stringForKey:@"ShadertoyShaderID"];
     NSString *shadertoyApiKey = [defaults stringForKey:@"ShadertoyApiKey"];
     NSString *shaderJson = [defaults stringForKey:@"ShaderJSON"];
     NSLog(@"shaderJson in configsheet %@", shaderJson);
-    [self.shadertoyUrlTextField setStringValue:shadertoyUrl];
+    [self.shadertoyShaderIDTextField setStringValue:shadertoyShaderID];
     [self.shadertoyAPIKeyTextField setStringValue:shadertoyApiKey];
 }
 
@@ -33,8 +33,8 @@ static NSString * const MyModuleName = @"diracdrifter.Shadertoy-Screensaver";
 {
     // Save current text
     NSUserDefaults *defaults = [ScreenSaverDefaults defaultsForModuleWithName:MyModuleName];
-    NSString *currentUrl = [self.shadertoyUrlTextField stringValue];
-    [defaults setObject:currentUrl forKey:@"ShadertoyUrl"];
+    NSString *currentUrl = [self.shadertoyShaderIDTextField stringValue];
+    [defaults setObject:currentUrl forKey:@"ShadertoyShaderID"];
 
     NSString *currentApiKey = [self.shadertoyAPIKeyTextField stringValue];
     [defaults setObject:currentApiKey forKey:@"ShadertoyApiKey"];

--- a/Shadertoy_ScreensaverConfigSheet.xib
+++ b/Shadertoy_ScreensaverConfigSheet.xib
@@ -18,7 +18,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="480" height="270"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1800" height="1131"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1800" height="1125"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                 <autoresizingMask key="autoresizingMask"/>

--- a/Shadertoy_ScreensaverConfigSheet.xib
+++ b/Shadertoy_ScreensaverConfigSheet.xib
@@ -8,7 +8,7 @@
         <customObject id="-2" userLabel="File's Owner" customClass="Shadertoy_ScreensaverConfigSheet">
             <connections>
                 <outlet property="shadertoyAPIKeyTextField" destination="Sgw-7m-aau" id="Ue2-6k-NGR"/>
-                <outlet property="shadertoyUrlTextField" destination="lvj-Wr-8v7" id="74F-Gm-K5W"/>
+                <outlet property="shadertoyShaderIDTextField" destination="lvj-Wr-8v7" id="74F-Gm-K5W"/>
                 <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
             </connections>
         </customObject>
@@ -26,7 +26,7 @@
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lvj-Wr-8v7">
                         <rect key="frame" x="130" y="184" width="221" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Shadertoy URL" drawsBackground="YES" id="az6-td-iAg">
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Shadertoy shader ID" drawsBackground="YES" id="az6-td-iAg">
                             <font key="font" usesAppearanceFont="YES"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -43,15 +43,6 @@
                             <action selector="doneButtonClicked:" target="-2" id="ZFT-T7-m3n"/>
                         </connections>
                     </button>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GbP-dl-j7X">
-                        <rect key="frame" x="193" y="213" width="95" height="16"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" lineBreakMode="clipping" title="Shadertoy URL" id="8EY-DA-LTU">
-                            <font key="font" metaFont="system"/>
-                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sgw-7m-aau">
                         <rect key="frame" x="130" y="124" width="221" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
@@ -65,6 +56,15 @@
                         <rect key="frame" x="183" y="153" width="115" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Shadertoy API key" id="IzB-iU-gML">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GbP-dl-j7X">
+                        <rect key="frame" x="176" y="213" width="128" height="16"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" title="Shadertoy shader ID" id="8EY-DA-LTU">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
Load an arbitrary shader from Shadertoy. The URL field actually takes in the shader ID instead of the URL which is a bit misleading and has to be fixed in the next commit/PR.

Possible ideas what to do next:
* Fix bug when using two monitors. For some reason the secondary monitor can show the lower left corner of the shader whereas in the main monitor the shader is shown correctly.
* Allow loading shader from the disk if the user doesn't want the shader to be publicly available. This should also be possible by setting the user-agent in the request to look like the request comes from a browser. However, this is not very gucci.
* Performance optimization and cleaning up code.